### PR TITLE
DataRecord Through Interface

### DIFF
--- a/BIDS.Parser.Variable.Tests/IDataRecordTests/ArrayStructureTests.cs
+++ b/BIDS.Parser.Variable.Tests/IDataRecordTests/ArrayStructureTests.cs
@@ -29,7 +29,7 @@ public class ArrayStructureTests
 			0
 		};
 
-		VariableStructure.ArrayStructure data = new(type, name);
+		VariableStructure.ArrayDataRecord data = new(type, name);
 
 		Assert.That(data.GetStructureBytes(), Is.EquivalentTo(expected));
 	}
@@ -85,7 +85,7 @@ public class ArrayStructureTests
 		})]
 	public void GetBytesTest(VariableDataType type, Array value, byte[] expected)
 	{
-		VariableStructure.ArrayStructure data = new(type, "test", value);
+		VariableStructure.ArrayDataRecord data = new(type, "test", value);
 
 		Assert.That(data.GetBytes(), Is.EquivalentTo(expected));
 	}

--- a/BIDS.Parser.Variable.Tests/ParseDataTypeRegisterCommand.Tests.cs
+++ b/BIDS.Parser.Variable.Tests/ParseDataTypeRegisterCommand.Tests.cs
@@ -174,7 +174,7 @@ public class ParseDataTypeRegisterCommandTests
 		Assert.That(actual.Records.Count, Is.EqualTo(1));
 
 		Assert.That(actual.Records[0], Is.EqualTo(
-			new VariableStructure.ArrayStructure(VariableDataType.Int32, "a", null))
+			new VariableStructure.ArrayDataRecord(VariableDataType.Int32, "a", null))
 		);
 	}
 
@@ -266,7 +266,7 @@ public class ParseDataTypeRegisterCommandTests
 			new VariableStructure.DataRecord(VariableDataType.UInt32, "h", null),
 			new VariableStructure.DataRecord(VariableDataType.UInt64, "i", null),
 
-			new VariableStructure.ArrayStructure(VariableDataType.Float16, "array", null),
+			new VariableStructure.ArrayDataRecord(VariableDataType.Float16, "array", null),
 
 			new VariableStructure.DataRecord(VariableDataType.Float16, "j", null),
 			new VariableStructure.DataRecord(VariableDataType.Float32, "k", null),

--- a/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
@@ -40,7 +40,7 @@ public class MemberInfoToVariableDataRecordListTests
 			Is.EquivalentTo(new List<VariableStructure.IDataRecord>()
 			{
 				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleClass.SampleIntProperty)),
-				new VariableStructure.ArrayStructure(VariableDataType.Int64, nameof(SampleClass.SampleLongArrayField)),
+				new VariableStructure.ArrayDataRecord(VariableDataType.Int64, nameof(SampleClass.SampleLongArrayField)),
 
 				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleBaseClass.SampleBaseIntProperty)),
 				new VariableStructure.DataRecord(VariableDataType.Int64, nameof(SampleBaseClass.SampleBaseLongField)),

--- a/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataRecordTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataRecordTests.cs
@@ -17,7 +17,7 @@ public class TypeToVariableDataRecordTests
 	{
 		Assert.That(
 			Utils.ToVariableDataRecord(type, name),
-			Is.EqualTo(new VariableStructure.ArrayStructure(expectedDataType, name))
+			Is.EqualTo(new VariableStructure.ArrayDataRecord(expectedDataType, name))
 		);
 	}
 

--- a/BIDS.Parser.Variable.Tests/VariableStructure.With.Tests.cs
+++ b/BIDS.Parser.Variable.Tests/VariableStructure.With.Tests.cs
@@ -56,7 +56,7 @@ public class VariableStructureTests
 		string structureName = "SampleStrcuture";
 		VariableStructure structure = new(0, structureName, new List<VariableStructure.IDataRecord>()
 		{
-			new VariableStructure.ArrayStructure(type, name, null)
+			new VariableStructure.ArrayDataRecord(type, name, null)
 		});
 
 		byte[] bytes = new byte[]
@@ -83,7 +83,7 @@ public class VariableStructureTests
 		VariableStructurePayload actual = structure.With(bytes.AsSpan());
 
 		Assert.That(actual.TryGetValue(name, out var actualRecord), Is.True);
-		if (actualRecord is not VariableStructure.ArrayStructure actualArrayRecord)
+		if (actualRecord is not VariableStructure.ArrayDataRecord actualArrayRecord)
 		{
 			Assert.Fail("actualRecord was not ArrayStructure");
 			return;
@@ -101,7 +101,7 @@ public class VariableStructureTests
 		VariableStructure structure = new(0, structureName, new List<VariableStructure.IDataRecord>()
 		{
 			new VariableStructure.DataRecord(VariableDataType.Boolean, "Bool", null),
-			new VariableStructure.ArrayStructure(VariableDataType.UInt8, "Array", null),
+			new VariableStructure.ArrayDataRecord(VariableDataType.UInt8, "Array", null),
 			new VariableStructure.DataRecord(VariableDataType.Int32, "Int32", null),
 		});
 
@@ -145,7 +145,7 @@ public class VariableStructureTests
 			Assert.That(actual["Bool"], Is.EqualTo(new VariableStructure.DataRecord(VariableDataType.Boolean, "Bool", true)));
 			Assert.That(actual["Int32"], Is.EqualTo(new VariableStructure.DataRecord(VariableDataType.Int32, "Int32", -2)));
 
-			if (actual["Array"] is not VariableStructure.ArrayStructure arrayStructure)
+			if (actual["Array"] is not VariableStructure.ArrayDataRecord arrayStructure)
 				Assert.Fail("dataName='Array' was not VariableStructure.ArrayStructure");
 			else
 				Assert.That(arrayStructure.ValueArray, Is.EquivalentTo(expected_array));

--- a/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
+++ b/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.3.0.1</Version>
+		<Version>1.4.0</Version>
 		<Authors>Tetsu Otter</Authors>
 		<Company>Tech Otter</Company>
 		<Product>BIDS Project</Product>

--- a/BIDS.Parser.Variable/Utils/TypeToVariableDataRecord.cs
+++ b/BIDS.Parser.Variable/Utils/TypeToVariableDataRecord.cs
@@ -25,12 +25,12 @@ public static partial class Utils
 			if (elemDataType == VariableDataType.Array)
 				throw new NotSupportedException("Currently, nested array is not supported.");
 
-			return new VariableStructure.ArrayStructure(elemDataType, name);
+			return new VariableStructure.ArrayDataRecord(elemDataType, name);
 		}
 
 		if (memberType == typeof(string))
 		{
-			return new VariableStructure.ArrayStructure(VariableDataType.UInt8, name);
+			return new VariableStructure.ArrayDataRecord(VariableDataType.UInt8, name);
 		}
 
 		return new VariableStructure.DataRecord(memberType.ToVariableDataType(), name);

--- a/BIDS.Parser.Variable/VariableCmdParser.cs
+++ b/BIDS.Parser.Variable/VariableCmdParser.cs
@@ -71,7 +71,7 @@ public class VariableCmdParser
 			string dataName = Utils.GetStringAndMove(ref bytes);
 
 			if (arrayElemDataType is VariableDataType elemDataType)
-				records.Add(new VariableStructure.ArrayStructure(elemDataType, dataName));
+				records.Add(new VariableStructure.ArrayDataRecord(elemDataType, dataName));
 			else
 				records.Add(new VariableStructure.DataRecord(dataType, dataName));
 		}

--- a/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
+++ b/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
@@ -38,7 +38,7 @@ public partial record VariableStructure
 		new T[]? ValueArray { set; }
 	}
 
-	public record ArrayStructure(VariableDataType ElemType, string Name, Array? ValueArray = null) : IArrayDataRecordWithValue, IArrayDataRecordWithValue_HasWithNewValue
+	public record ArrayDataRecord(VariableDataType ElemType, string Name, Array? ValueArray = null) : IArrayDataRecordWithValue, IArrayDataRecordWithValue_HasWithNewValue
 	{
 		VariableDataType IDataRecord.Type => VariableDataType.Array;
 

--- a/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
+++ b/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
@@ -26,7 +26,7 @@ public partial record VariableStructure
 	}
 	public interface IArrayDataRecordWithValue_HasWithNewValue<T> : IArrayDataRecordWithValue_HasWithNewValue
 	{
-		IArrayDataRecordWithValue_HasWithNewValue WithNewValue(T[]? NewValue);
+		IArrayDataRecordWithValue_HasWithNewValue<T> WithNewValue(T[]? NewValue);
 	}
 
 	public interface IArrayDataRecordWithValue_CanSet : IArrayDataRecord

--- a/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
+++ b/BIDS.Parser.Variable/VariableStructure/VariableStructure.ArrayStructure.cs
@@ -6,7 +6,39 @@ namespace BIDS.Parser.Variable;
 
 public partial record VariableStructure
 {
-	public record ArrayStructure(VariableDataType ElemType, string Name, Array? ValueArray = null) : IDataRecord
+	public interface IArrayDataRecord : IDataRecord
+	{
+		VariableDataType ElemType { get; }
+	}
+
+	public interface IArrayDataRecordWithValue : IArrayDataRecord
+	{
+		Array? ValueArray { get; }
+	}
+	public interface IArrayDataRecordWithValue<T> : IArrayDataRecordWithValue
+	{
+		new T[]? ValueArray { get; }
+	}
+
+	public interface IArrayDataRecordWithValue_HasWithNewValue : IArrayDataRecord
+	{
+		IArrayDataRecordWithValue_HasWithNewValue WithNewValue(Array? NewValue);
+	}
+	public interface IArrayDataRecordWithValue_HasWithNewValue<T> : IArrayDataRecordWithValue_HasWithNewValue
+	{
+		IArrayDataRecordWithValue_HasWithNewValue WithNewValue(T[]? NewValue);
+	}
+
+	public interface IArrayDataRecordWithValue_CanSet : IArrayDataRecord
+	{
+		Array? ValueArray { set; }
+	}
+	public interface IArrayDataRecordWithValue_CanSet<T> : IArrayDataRecordWithValue_CanSet
+	{
+		new T[]? ValueArray { set; }
+	}
+
+	public record ArrayStructure(VariableDataType ElemType, string Name, Array? ValueArray = null) : IArrayDataRecordWithValue, IArrayDataRecordWithValue_HasWithNewValue
 	{
 		VariableDataType IDataRecord.Type => VariableDataType.Array;
 
@@ -56,5 +88,11 @@ public partial record VariableStructure
 
 			return arr;
 		}
+
+		public IArrayDataRecordWithValue_HasWithNewValue WithNewValue(Array? NewValue)
+			=> this with
+			{
+				ValueArray = NewValue
+			};
 	}
 }

--- a/BIDS.Parser.Variable/VariableStructure/VariableStructure.DataRecord.cs
+++ b/BIDS.Parser.Variable/VariableStructure/VariableStructure.DataRecord.cs
@@ -6,7 +6,35 @@ namespace BIDS.Parser.Variable;
 
 public partial record VariableStructure
 {
-	public record DataRecord(VariableDataType Type, string Name, object? Value = null) : IDataRecord
+	public interface IDataRecordWithValue : IDataRecord
+	{
+		object? Value { get; }
+	}
+	public interface IDataRecordWithValue<T> : IDataRecordWithValue
+	{
+		new T? Value { get; }
+	}
+
+
+	public interface IDataRecordWithValue_HasWithNewValue : IDataRecord
+	{
+		IDataRecordWithValue_HasWithNewValue WithNewValue(object? NewValue);
+	}
+	public interface IDataRecordWithValue_HasWithNewValue<T> : IDataRecordWithValue_HasWithNewValue
+	{
+		IDataRecordWithValue_HasWithNewValue<T> WithNewValue(T? NewValue);
+	}
+
+	public interface IDataRecordWithValue_CanSet : IDataRecord
+	{
+		object? Value { set; }
+	}
+	public interface IDataRecordWithValue_CanSet<T> : IDataRecordWithValue_CanSet
+	{
+		new T? Value { set; }
+	}
+
+	public record DataRecord(VariableDataType Type, string Name, object? Value = null) : IDataRecordWithValue, IDataRecordWithValue_HasWithNewValue
 	{
 		public IDataRecord With(ref ReadOnlySpan<byte> bytes)
 		{
@@ -21,5 +49,11 @@ public partial record VariableStructure
 
 		public IEnumerable<byte> GetBytes()
 			=> this.Type.GetBytes(this.Value);
+
+		public IDataRecordWithValue_HasWithNewValue WithNewValue(object? NewValue)
+			=> this with
+			{
+				Value = NewValue
+			};
 	}
 }

--- a/BIDSSMemLib.Variable.RandomWriter/RandomValueGenerator.cs
+++ b/BIDSSMemLib.Variable.RandomWriter/RandomValueGenerator.cs
@@ -165,7 +165,7 @@ public class RandomValueGenerator
 	public VariableStructure.IDataRecord GetDataRecordWithRandomValue(string name, VariableDataType type)
 		=> type == VariableDataType.Array ? GetArrayStructureWithRandomValue(name) : new VariableStructure.DataRecord(type, name, Get(type));
 
-	public VariableStructure.ArrayStructure GetArrayStructureWithRandomValue(string name)
+	public VariableStructure.ArrayDataRecord GetArrayStructureWithRandomValue(string name)
 	{
 		VariableDataType type = GetDataType();
 
@@ -175,12 +175,12 @@ public class RandomValueGenerator
 		return GetArrayStructureWithRandomValue(name, type);
 	}
 
-	public VariableStructure.ArrayStructure GetArrayStructureWithRandomValue(string name, VariableDataType type)
+	public VariableStructure.ArrayDataRecord GetArrayStructureWithRandomValue(string name, VariableDataType type)
 	{
 		if (type == VariableDataType.Array)
 			throw new NotSupportedException("Nested Array is not Supported");
 
-		return new VariableStructure.ArrayStructure(type, name, GetArray(type));
+		return new VariableStructure.ArrayDataRecord(type, name, GetArray(type));
 	}
 	#endregion
 
@@ -206,7 +206,7 @@ public class RandomValueGenerator
 		=> dataRecord switch
 		{
 			VariableStructure.DataRecord v => WithRandomValue(v),
-			VariableStructure.ArrayStructure v => WithRandomValue(v),
+			VariableStructure.ArrayDataRecord v => WithRandomValue(v),
 
 			_ => throw new NotSupportedException($"The IDataRecord {dataRecord.GetType()} is not supported")
 		};
@@ -217,7 +217,7 @@ public class RandomValueGenerator
 			Value = Get(dataRecord.Type)
 		};
 
-	public VariableStructure.ArrayStructure WithRandomValue(in VariableStructure.ArrayStructure dataRecord)
+	public VariableStructure.ArrayDataRecord WithRandomValue(in VariableStructure.ArrayDataRecord dataRecord)
 		=> dataRecord with
 		{
 			ValueArray = GetArray(dataRecord.ElemType)

--- a/BIDSSMemLib.Variable.RandomWriter/RandomValueGenerator.cs
+++ b/BIDSSMemLib.Variable.RandomWriter/RandomValueGenerator.cs
@@ -205,22 +205,10 @@ public class RandomValueGenerator
 	public VariableStructure.IDataRecord WithRandomValue(in VariableStructure.IDataRecord dataRecord)
 		=> dataRecord switch
 		{
-			VariableStructure.DataRecord v => WithRandomValue(v),
-			VariableStructure.ArrayDataRecord v => WithRandomValue(v),
+			VariableStructure.IDataRecordWithValue_HasWithNewValue v => v.WithNewValue(Get(v.Type)),
+			VariableStructure.IArrayDataRecordWithValue_HasWithNewValue v => v.WithNewValue(GetArray(v.ElemType)),
 
 			_ => throw new NotSupportedException($"The IDataRecord {dataRecord.GetType()} is not supported")
-		};
-
-	public VariableStructure.DataRecord WithRandomValue(in VariableStructure.DataRecord dataRecord)
-		=> dataRecord with
-		{
-			Value = Get(dataRecord.Type)
-		};
-
-	public VariableStructure.ArrayDataRecord WithRandomValue(in VariableStructure.ArrayDataRecord dataRecord)
-		=> dataRecord with
-		{
-			ValueArray = GetArray(dataRecord.ElemType)
 		};
 	#endregion
 

--- a/BIDSSMemLib.Variable.Tests/VariableSMemTests.SampleClass.cs
+++ b/BIDSSMemLib.Variable.Tests/VariableSMemTests.SampleClass.cs
@@ -23,11 +23,11 @@ public partial class VariableSMemTests
 			= new(VariableDataType.Float64, "vFloat64");
 
 		public string? vString;
-		public static readonly VariableStructure.ArrayStructure Expected_vString
+		public static readonly VariableStructure.ArrayDataRecord Expected_vString
 			= new(VariableDataType.UInt8, "vString");
 
 		public int[]? vInt32Arr;
-		public static readonly VariableStructure.ArrayStructure Expected_vInt32Arr
+		public static readonly VariableStructure.ArrayDataRecord Expected_vInt32Arr
 			= new(VariableDataType.Int32, "vInt32Arr");
 
 		public override bool Equals(object? obj)

--- a/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
+++ b/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
@@ -282,10 +282,10 @@ public partial class VariableSMemTests
 		ArrayStructureInPayloadTestUtil(payload, nameof(SampleClass.vInt32Arr), SampleClass.Expected_vInt32Arr, SampleData.vInt32Arr);
 	}
 
-	static void ArrayStructureInPayloadTestUtil(VariableStructurePayload payload, string name, VariableStructure.ArrayStructure expectedStructure, Array expectedArray)
+	static void ArrayStructureInPayloadTestUtil(VariableStructurePayload payload, string name, VariableStructure.ArrayDataRecord expectedStructure, Array expectedArray)
 	{
 		Assert.That(payload, Does.ContainKey(name));
-		VariableStructure.ArrayStructure? actual = payload[name] as VariableStructure.ArrayStructure;
+		VariableStructure.ArrayDataRecord? actual = payload[name] as VariableStructure.ArrayDataRecord;
 
 		Assert.That(actual, Is.EqualTo(expectedStructure with
 		{

--- a/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
+++ b/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
-		<Version>1.2.0.1</Version>
+		<Version>1.3.0</Version>
 		<Nullable>enable</Nullable>
 		<Assemblyname>TR.BIDSSMemLib.Variable</Assemblyname>
 		<RootNamespace>TR.BIDSSMemLib</RootNamespace>

--- a/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
@@ -55,8 +55,8 @@ public partial class VariableSMem
 	internal static object? GetValueObjectFromDataRecord(VariableStructure.IDataRecord dataRecord, bool isString)
 		=> dataRecord switch
 		{
-			VariableStructure.DataRecord v => v.Value,
-			VariableStructure.ArrayDataRecord v =>
+			VariableStructure.IDataRecordWithValue v => v.Value,
+			VariableStructure.IArrayDataRecordWithValue v =>
 				(isString && v.ValueArray is byte[] arr)
 				? DefaultEncoding.GetString(arr)
 				: v.ValueArray,
@@ -73,7 +73,7 @@ public partial class VariableSMem
 
 		if (memberVDType == VariableDataType.Array)
 		{
-			if (memberDataRecord is not VariableStructure.ArrayDataRecord arrayStructure)
+			if (memberDataRecord is not VariableStructure.IArrayDataRecordWithValue_HasWithNewValue arrayStructure)
 				throw new Exception("Type mismatch (Given member was array, but dataRecord was not ArrayStructure)");
 
 			if (memberType == typeof(string))
@@ -81,10 +81,7 @@ public partial class VariableSMem
 				if (value is not string s)
 					throw new Exception($"Given Value is not string or null (GivenType: {memberType})");
 
-				return arrayStructure with
-				{
-					ValueArray = DefaultEncoding.GetBytes(s)
-				};
+				return arrayStructure.WithNewValue(DefaultEncoding.GetBytes(s));
 			}
 
 			// elementの型チェック
@@ -95,20 +92,14 @@ public partial class VariableSMem
 			if (arrayStructure.ElemType != elemVDType)
 				throw new Exception($"Type mismatch (given: {elemVDType} / Initialized with: {arrayStructure.ElemType})");
 
-			return arrayStructure with
-			{
-				ValueArray = value as Array
-			};
+			return arrayStructure.WithNewValue(value as Array);
 		}
 		else
 		{
-			if (memberDataRecord is not VariableStructure.DataRecord dataRecord)
+			if (memberDataRecord is not VariableStructure.IDataRecordWithValue_HasWithNewValue dataRecord)
 				throw new Exception("Type mismatch (Given member was normal data, but dataRecord was not DataRecord)");
 
-			return dataRecord with
-			{
-				Value = value
-			};
+			return dataRecord.WithNewValue(value);
 		}
 	}
 }

--- a/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
@@ -56,7 +56,7 @@ public partial class VariableSMem
 		=> dataRecord switch
 		{
 			VariableStructure.DataRecord v => v.Value,
-			VariableStructure.ArrayStructure v =>
+			VariableStructure.ArrayDataRecord v =>
 				(isString && v.ValueArray is byte[] arr)
 				? DefaultEncoding.GetString(arr)
 				: v.ValueArray,
@@ -73,7 +73,7 @@ public partial class VariableSMem
 
 		if (memberVDType == VariableDataType.Array)
 		{
-			if (memberDataRecord is not VariableStructure.ArrayStructure arrayStructure)
+			if (memberDataRecord is not VariableStructure.ArrayDataRecord arrayStructure)
 				throw new Exception("Type mismatch (Given member was array, but dataRecord was not ArrayStructure)");
 
 			if (memberType == typeof(string))

--- a/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
@@ -81,8 +81,6 @@ public partial class VariableSMem
 				if (value is not string s)
 					throw new Exception($"Given Value is not string or null (GivenType: {memberType})");
 
-				// TODO: Boxingによりパフォーマンス的に好ましくないはず。極力Boxingなしにできるように書き直す
-				// Maybe?: Array型が適切...?
 				return arrayStructure with
 				{
 					ValueArray = DefaultEncoding.GetBytes(s)

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -260,8 +260,8 @@ public partial class VariableSMem : IDisposable
 
 			if (iDataRecord.Type != gotData.Type)
 				continue;
-			if (gotData is VariableStructure.ArrayStructure v1
-				&& iDataRecord is VariableStructure.ArrayStructure v2
+			if (gotData is VariableStructure.ArrayDataRecord v1
+				&& iDataRecord is VariableStructure.ArrayDataRecord v2
 				&& v1.ElemType != v2.ElemType)
 				continue;
 

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -195,7 +195,15 @@ public partial class VariableSMem : IDisposable
 		if (!SMemIF.ReadArray(ContentAreaOffset + sizeof(long), content, 0, content.Length))
 			throw new AccessViolationException("Read from SMem failed");
 
-		return Structure.With(content);
+		VariableStructurePayload gotPayload = Structure.With(content);
+
+		for (int i = 0; i < _Members.Count; i++)
+		{
+			if (gotPayload.TryGetValue(_Members[i].Name, out VariableStructure.IDataRecord? dataRecord))
+				_Members[i] = dataRecord;
+		}
+
+		return gotPayload;
 	}
 
 	/// <summary>

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -260,8 +260,8 @@ public partial class VariableSMem : IDisposable
 
 			if (iDataRecord.Type != gotData.Type)
 				continue;
-			if (gotData is VariableStructure.ArrayDataRecord v1
-				&& iDataRecord is VariableStructure.ArrayDataRecord v2
+			if (gotData is VariableStructure.IArrayDataRecord v1
+				&& iDataRecord is VariableStructure.IArrayDataRecord v2
 				&& v1.ElemType != v2.ElemType)
 				continue;
 

--- a/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
+++ b/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<LangVersion>10</LangVersion>
+		<Version>1.3.0</Version>
 		<Nullable>enable</Nullable>
 		<AssemblyName>TR.VariableSMemMonitor.Core</AssemblyName>
 		<RootNamespace>TR.VariableSMemMonitor.Core</RootNamespace>

--- a/VariableSMemMonitor.Core/VariableSMemWatcher.cs
+++ b/VariableSMemMonitor.Core/VariableSMemWatcher.cs
@@ -49,7 +49,7 @@ public class VariableSMemWatcher : IDisposable
 
 		foreach (var v in payload.Values)
 		{
-			if (v is VariableStructure.DataRecord data)
+			if (v is VariableStructure.IDataRecordWithValue data)
 			{
 				object? lastValue = CurrentValues[v.Name];
 
@@ -61,7 +61,7 @@ public class VariableSMemWatcher : IDisposable
 					CurrentValues[v.Name] = data.Value;
 				}
 			}
-			else if (v is VariableStructure.ArrayDataRecord arr)
+			else if (v is VariableStructure.IArrayDataRecordWithValue arr)
 			{
 				Array? lastValue = CurrentValues[v.Name] as Array;
 

--- a/VariableSMemMonitor.Core/VariableSMemWatcher.cs
+++ b/VariableSMemMonitor.Core/VariableSMemWatcher.cs
@@ -61,7 +61,7 @@ public class VariableSMemWatcher : IDisposable
 					CurrentValues[v.Name] = data.Value;
 				}
 			}
-			else if (v is VariableStructure.ArrayStructure arr)
+			else if (v is VariableStructure.ArrayDataRecord arr)
 			{
 				Array? lastValue = CurrentValues[v.Name] as Array;
 


### PR DESCRIPTION
`BIDS.Parser.Variable`のDataRecord系について、インターフェイスを利用してアクセスする形にした

これにより、独自のDataRecordを用いて共有メモリへのアクセスを行う等が可能になる