### PR TITLE
VariableData set default value

### DIFF
--- a/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
+++ b/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
@@ -9,11 +9,17 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />

--- a/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/MemberInfoToVariableDataRecordListTests.cs
@@ -35,16 +35,36 @@ public class MemberInfoToVariableDataRecordListTests
 	[Test]
 	public void NormalTest()
 	{
-		Assert.That(
-			typeof(SampleClass).ToVariableDataRecordList(),
-			Is.EquivalentTo(new List<VariableStructure.IDataRecord>()
-			{
-				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleClass.SampleIntProperty)),
-				new VariableStructure.ArrayDataRecord(VariableDataType.Int64, nameof(SampleClass.SampleLongArrayField)),
+		var actual = typeof(SampleClass).ToVariableDataRecordList();
 
-				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleBaseClass.SampleBaseIntProperty)),
-				new VariableStructure.DataRecord(VariableDataType.Int64, nameof(SampleBaseClass.SampleBaseLongField)),
-			})
-		);
+		Assert.Multiple(() =>
+		{
+			Assert.That(
+				actual,
+				Is.EquivalentTo(new List<VariableStructure.IDataRecord>()
+				{
+				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleClass.SampleIntProperty), (int)0),
+				new VariableStructure.DataRecord(VariableDataType.Int32, nameof(SampleBaseClass.SampleBaseIntProperty), (int)0),
+
+				actual[2],
+				new VariableStructure.DataRecord(VariableDataType.Int64, nameof(SampleBaseClass.SampleBaseLongField), (long)0),
+				})
+			);
+
+			var expect_2 = new VariableStructure.ArrayDataRecord(VariableDataType.Int64, nameof(SampleClass.SampleLongArrayField), Array.Empty<int>());
+
+			if (actual[2] is not VariableStructure.IArrayDataRecordWithValue actual_2)
+			{
+				Assert.Fail("Invalid Type (actual[1])");
+				return;
+			}
+
+			Assert.That(actual_2, Is.EqualTo(expect_2 with
+			{
+				ValueArray = actual_2.ValueArray
+			}));
+
+			Assert.That(actual_2.ValueArray, Is.EquivalentTo(expect_2.ValueArray));
+		});
 	}
 }

--- a/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataRecordTests.cs
+++ b/BIDS.Parser.Variable.Tests/UtilsTests/TypeToVariableDataRecordTests.cs
@@ -7,7 +7,7 @@ public class TypeToVariableDataRecordTests
 	{
 		Assert.That(
 			Utils.ToVariableDataRecord(type, name),
-			Is.EqualTo(new VariableStructure.DataRecord(expectedDataType, name))
+			Is.EqualTo(new VariableStructure.DataRecord(expectedDataType, name, Utils.GetDefaultValue(expectedDataType)))
 		);
 	}
 
@@ -15,10 +15,23 @@ public class TypeToVariableDataRecordTests
 	[TestCase(typeof(string), "ABC", VariableDataType.UInt8)]
 	public void NormalTest_WithTypeAndName_ReturnArrayStructure(Type type, string name, VariableDataType expectedDataType)
 	{
+		var expected = new VariableStructure.ArrayDataRecord(expectedDataType, name, Utils.GetSpecifiedTypeArray(expectedDataType, 0));
+
+		if (Utils.ToVariableDataRecord(type, name) is not VariableStructure.IArrayDataRecordWithValue actual)
+		{
+			Assert.Fail("actual was not `IArrayDataRecordWithValue");
+			return;
+		}
+
 		Assert.That(
-			Utils.ToVariableDataRecord(type, name),
-			Is.EqualTo(new VariableStructure.ArrayDataRecord(expectedDataType, name))
+			actual,
+			Is.EqualTo(expected with
+			{
+				ValueArray = actual.ValueArray
+			})
 		);
+
+		Assert.That(actual.ValueArray, Is.EquivalentTo(expected.ValueArray));
 	}
 
 	[TestCase(typeof(object[][]), "ABC", typeof(NotSupportedException))]
@@ -48,7 +61,7 @@ public class TypeToVariableDataRecordTests
 	{
 		Assert.That(
 			typeof(SampleClass).GetMember(memberName)[0].ToVariableDataRecord(),
-			Is.EqualTo(new VariableStructure.DataRecord(expectedDataType, memberName))
+			Is.EqualTo(new VariableStructure.DataRecord(expectedDataType, memberName, Utils.GetDefaultValue(expectedDataType)))
 		);
 	}
 

--- a/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
+++ b/BIDS.Parser.Variable/BIDS.Parser.Variable.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.4.1</Version>
+		<Version>1.5.0</Version>
 		<Authors>Tetsu Otter</Authors>
 		<Company>Tech Otter</Company>
 		<Product>BIDS Project</Product>

--- a/BIDS.Parser.Variable/Utils/GetDefaultValue.cs
+++ b/BIDS.Parser.Variable/Utils/GetDefaultValue.cs
@@ -1,0 +1,34 @@
+namespace BIDS.Parser.Variable;
+
+public static partial class Utils
+{
+	public static object? GetDefaultValue(VariableStructure.IDataRecord dataRecord)
+		=> dataRecord is VariableStructure.IArrayDataRecord v
+			? GetSpecifiedTypeArray(v.ElemType, 0)
+			: GetDefaultValue(dataRecord.Type);
+
+	public static object? GetDefaultValue(VariableDataType type)
+		=> type switch
+		{
+			VariableDataType.Boolean => default(bool),
+
+			VariableDataType.Int8 => default(sbyte),
+			VariableDataType.Int16 => default(short),
+			VariableDataType.Int32 => default(int),
+			VariableDataType.Int64 => default(long),
+
+			VariableDataType.UInt8 => default(byte),
+			VariableDataType.UInt16 => default(ushort),
+			VariableDataType.UInt32 => default(uint),
+			VariableDataType.UInt64 => default(ulong),
+
+#if NET5_0_OR_GREATER
+			VariableDataType.Float16 => default(System.Half),
+#endif
+
+			VariableDataType.Float32 => default(float),
+			VariableDataType.Float64 => default(double),
+
+			_ => null,
+		};
+}

--- a/BIDS.Parser.Variable/Utils/TypeToVariableDataRecord.cs
+++ b/BIDS.Parser.Variable/Utils/TypeToVariableDataRecord.cs
@@ -25,14 +25,15 @@ public static partial class Utils
 			if (elemDataType == VariableDataType.Array)
 				throw new NotSupportedException("Currently, nested array is not supported.");
 
-			return new VariableStructure.ArrayDataRecord(elemDataType, name);
+			return new VariableStructure.ArrayDataRecord(elemDataType, name, GetSpecifiedTypeArray(elemDataType, 0));
 		}
 
 		if (memberType == typeof(string))
 		{
-			return new VariableStructure.ArrayDataRecord(VariableDataType.UInt8, name);
+			return new VariableStructure.ArrayDataRecord(VariableDataType.UInt8, name, Array.Empty<byte>());
 		}
 
-		return new VariableStructure.DataRecord(memberType.ToVariableDataType(), name);
+		VariableDataType variableDataType = memberType.ToVariableDataType();
+		return new VariableStructure.DataRecord(variableDataType, name, GetDefaultValue(variableDataType));
 	}
 }

--- a/BIDS.Parser.Variable/VariableCmdParser.cs
+++ b/BIDS.Parser.Variable/VariableCmdParser.cs
@@ -73,9 +73,9 @@ public class VariableCmdParser
 			string dataName = Utils.GetStringAndMove(ref bytes);
 
 			if (arrayElemDataType is VariableDataType elemDataType)
-				records.Add(new VariableStructure.ArrayDataRecord(elemDataType, dataName));
+				records.Add(new VariableStructure.ArrayDataRecord(elemDataType, dataName, Utils.GetSpecifiedTypeArray(elemDataType, 0)));
 			else
-				records.Add(new VariableStructure.DataRecord(dataType, dataName));
+				records.Add(new VariableStructure.DataRecord(dataType, dataName, Utils.GetDefaultValue(dataType)));
 		}
 
 		return new VariableStructure(cmdDataType, structureName, records);

--- a/BIDSSMemLib.Variable.Tests/BIDSSMemLib.Variable.Tests.csproj
+++ b/BIDSSMemLib.Variable.Tests/BIDSSMemLib.Variable.Tests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
 		<PackageReference Include="NUnit.Analyzers" Version="3.5.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/BIDSSMemLib.Variable.Tests/VariableSMemTests.SampleClass.cs
+++ b/BIDSSMemLib.Variable.Tests/VariableSMemTests.SampleClass.cs
@@ -8,27 +8,27 @@ public partial class VariableSMemTests
 	{
 		public ushort vUInt16;
 		public static readonly VariableStructure.DataRecord Expected_vUInt16
-			= new(VariableDataType.UInt16, "vUInt16");
+			= new(VariableDataType.UInt16, "vUInt16", (ushort)0);
 
 		public int vInt32;
 		public static readonly VariableStructure.DataRecord Expected_vInt32
-			= new(VariableDataType.Int32, "vInt32");
+			= new(VariableDataType.Int32, "vInt32", (int)0);
 
 		public long vInt64;
 		public static readonly VariableStructure.DataRecord Expected_vInt64
-			= new(VariableDataType.Int64, "vInt64");
+			= new(VariableDataType.Int64, "vInt64", (long)0);
 
 		public double vFloat64;
 		public static readonly VariableStructure.DataRecord Expected_vFloat64
-			= new(VariableDataType.Float64, "vFloat64");
+			= new(VariableDataType.Float64, "vFloat64", (double)0);
 
 		public string? vString;
 		public static readonly VariableStructure.ArrayDataRecord Expected_vString
-			= new(VariableDataType.UInt8, "vString");
+			= new(VariableDataType.UInt8, "vString", Array.Empty<byte>());
 
 		public int[]? vInt32Arr;
 		public static readonly VariableStructure.ArrayDataRecord Expected_vInt32Arr
-			= new(VariableDataType.Int32, "vInt32Arr");
+			= new(VariableDataType.Int32, "vInt32Arr", Array.Empty<int>());
 
 		public override bool Equals(object? obj)
 			=> obj is SampleClass v

--- a/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
+++ b/BIDSSMemLib.Variable.Tests/VariableSMemTests.cs
@@ -16,15 +16,35 @@ public partial class VariableSMemTests
 
 		VariableSMem<SampleClass> variableSMem = new(SMemIF);
 
+		if (variableSMem.Members[4] is not VariableStructure.ArrayDataRecord actualString)
+		{
+			Assert.Fail("Type Missmatch (variableSMem.Members[4] was not string)");
+			return;
+		}
+		if (variableSMem.Members[5] is not VariableStructure.ArrayDataRecord actualInt32Arr)
+		{
+			Assert.Fail("Type Missmatch (variableSMem.Members[5] was not int[])");
+			return;
+		}
+
 		Assert.That(variableSMem.Members, Is.EquivalentTo(new VariableStructure.IDataRecord[]
 		{
 			SampleClass.Expected_vUInt16,
 			SampleClass.Expected_vInt32,
 			SampleClass.Expected_vInt64,
 			SampleClass.Expected_vFloat64,
-			SampleClass.Expected_vString,
-			SampleClass.Expected_vInt32Arr,
+			SampleClass.Expected_vString with
+			{
+				ValueArray = actualString.ValueArray
+			},
+			SampleClass.Expected_vInt32Arr with
+			{
+				ValueArray = actualInt32Arr.ValueArray
+			},
 		}));
+
+		Assert.That(actualString.ValueArray, Is.EquivalentTo(SampleClass.Expected_vString.ValueArray));
+		Assert.That(actualInt32Arr.ValueArray, Is.EquivalentTo(SampleClass.Expected_vInt32Arr.ValueArray));
 
 		// `GetStructureBytes`メソッドは正常に動作していることを期待する
 		byte[] expectedMemory =
@@ -336,6 +356,30 @@ public partial class VariableSMemTests
 
 		VariableSMem variableSMem1 = VariableSMem.CreateWithoutType(new SMemIFMock(SMemIF));
 
-		Assert.That(variableSMem1.Members, Is.EquivalentTo(variableSMem.Members));
+		var members0 = variableSMem.Members;
+		var members1 = variableSMem1.Members;
+
+		if (members0.Count != members1.Count)
+		{
+			Assert.Fail("Members Count Missmatch");
+			return;
+		}
+
+		for (int i = 0; i < members0.Count; i++)
+		{
+			if (members0[i] is VariableStructure.ArrayDataRecord v0 && members1[i] is VariableStructure.ArrayDataRecord v1)
+			{
+				Assert.That(v1, Is.EqualTo(v0 with
+				{
+					ValueArray = v1.ValueArray
+				}));
+
+				Assert.That(v1.ValueArray, Is.EquivalentTo(v0.ValueArray));
+			}
+			else
+			{
+				Assert.That(members1[i], Is.EqualTo(members0[i]));
+			}
+		}
 	}
 }

--- a/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
+++ b/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
 		<Nullable>enable</Nullable>
 		<Assemblyname>TR.BIDSSMemLib.Variable</Assemblyname>
 		<RootNamespace>TR.BIDSSMemLib</RootNamespace>
@@ -15,6 +15,6 @@
 		<PackageReference Include="TR.SMemCtrler.AutoReadSupporter" Version="1.1.0.1" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />
+		<ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />
 	</ItemGroup>
 </Project>

--- a/VariableSMemMonitor.Core.Tests/NameSMemWatcher.Tests.cs
+++ b/VariableSMemMonitor.Core.Tests/NameSMemWatcher.Tests.cs
@@ -15,7 +15,7 @@ public class NameSMemWatcherTests
 	{
 		SMemIFMock memory = new("test", 0x1000);
 
-		NameSMemWatcher watcher = new();
+		NameSMemWatcher watcher = new(memory);
 
 		IReadOnlyList<string> newNames = watcher.CheckNewName();
 

--- a/VariableSMemMonitor.Core.Tests/VariableSMemMonitor.Core.Tests.csproj
+++ b/VariableSMemMonitor.Core.Tests/VariableSMemMonitor.Core.Tests.csproj
@@ -7,11 +7,17 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 		<PackageReference Include="TR.SMemIF.Mock" Version="1.1.0.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/VariableSMemMonitor.Core.Tests/VariableSMemWatcher.Tests.cs
+++ b/VariableSMemMonitor.Core.Tests/VariableSMemWatcher.Tests.cs
@@ -35,10 +35,10 @@ public class VariableSMemWatcherTests
 		Assert.Multiple(() =>
 		{
 			Assert.That(changedValues.SMemName, Is.EqualTo(memory.SMemName));
-			Assert.That(changedValues.ChangedValuesDic, Has.Count.EqualTo(2));
 
-			Assert.That(changedValues.ChangedValuesDic[nameof(BasicSampleClass.IntValue)], Is.EqualTo((int)0));
-			Assert.That(changedValues.ChangedValuesDic[nameof(BasicSampleClass.UInt16Value)], Is.EqualTo((ushort)0));
+			// 初期化時点から変化がないため、`ChangedValue`も存在しない。
+			// なお、初期値は`ChangedValue`に含まれない。
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.Zero);
 		});
 	}
 
@@ -55,15 +55,7 @@ public class VariableSMemWatcherTests
 		Assert.Multiple(() =>
 		{
 			Assert.That(changedValues.SMemName, Is.EqualTo(memory.SMemName));
-			Assert.That(changedValues.ChangedValuesDic, Has.Count.EqualTo(4));
-
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.IntValue)], Is.EqualTo((int)0));
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.UInt16Value)], Is.EqualTo((ushort)0));
-
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleString)], Has.Length.Zero);
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleString)], Is.EqualTo(string.Empty));
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleDoubleArr)], Has.Length.Zero);
-			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleDoubleArr)].GetType(), Is.EqualTo(typeof(double[])));
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.Zero);
 		});
 	}
 
@@ -76,7 +68,7 @@ public class VariableSMemWatcherTests
 
 		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
 
-		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.EqualTo(2));
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
 
 		BasicSampleClass data = new()
 		{
@@ -119,7 +111,7 @@ public class VariableSMemWatcherTests
 
 		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
 
-		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.EqualTo(4));
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
 
 		ArraySampleClass data = new()
 		{

--- a/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
+++ b/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<LangVersion>10</LangVersion>
-		<Version>1.4.1</Version>
+		<Version>1.5.0</Version>
 		<Nullable>enable</Nullable>
 		<AssemblyName>TR.VariableSMemMonitor.Core</AssemblyName>
 		<RootNamespace>TR.VariableSMemMonitor.Core</RootNamespace>

--- a/VariableSMemMonitor.Core/VariableSMemWatcher.cs
+++ b/VariableSMemMonitor.Core/VariableSMemWatcher.cs
@@ -39,12 +39,13 @@ public class VariableSMemWatcher : IDisposable
 		foreach (var v in VSMem.Structure.Records)
 		{
 			// Structure指定で初期化されて、かつValue / ValueArrayに値が保存されていた場合に限り初期値が設定される
+			// それ以外の場合は、それぞれの型のデフォルト値が設定される (配列であれば空の配列)
 			_CurrentValues.Add(v.Name, v switch
 			{
 				VariableStructure.IDataRecordWithValue dataRecord => dataRecord.Value,
 				VariableStructure.IArrayDataRecordWithValue dataRecord => dataRecord.ValueArray,
 
-				_ => null,
+				_ => Utils.GetDefaultValue(v),
 			});
 		}
 	}


### PR DESCRIPTION
`IDataRecord`系の各種について、初期化時点で`Value`に`null`が入っていると扱いづらいため、初期値をセットするようにした。

この関係で、AutoReadプロジェクトでは初回に`ChangedValues`が存在しなくなるようになった。