### PR TITLE
Fix bugs

### DIFF
--- a/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
+++ b/BIDS.Parser.Variable.Tests/BIDS.Parser.Variable.Tests.csproj
@@ -20,6 +20,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\BIDS.Parser.Variable\BIDS.Parser.Variable.csproj" />

--- a/BIDS.Parser.Variable.Tests/VariableStructure.GetStructureBytes.Tests.cs
+++ b/BIDS.Parser.Variable.Tests/VariableStructure.GetStructureBytes.Tests.cs
@@ -1,0 +1,81 @@
+namespace BIDS.Parser.Variable.Tests;
+
+public class VariableStructure_GetStructureBytesTest
+{
+	[Test]
+	public void Test()
+	{
+		VariableStructure structure = new(259, "SampleDataClass", new List<VariableStructure.IDataRecord>()
+		{
+			new VariableStructure.DataRecord(VariableDataType.Boolean, "PL_AtsS_White"),
+			new VariableStructure.DataRecord(VariableDataType.Boolean, "PL_AtsS_Red"),
+		});
+
+		Assert.That(structure.GetStructureBytes(), Is.EquivalentTo(new byte[]
+		{
+			// Structure ID (0x0103 = 259)
+			0x03,
+			0x01,
+			0x00,
+			0x00,
+
+			// Structure Name
+			(byte)'S',
+			(byte)'a',
+			(byte)'m',
+			(byte)'p',
+			(byte)'l',
+			(byte)'e',
+			(byte)'D',
+			(byte)'a',
+			(byte)'t',
+			(byte)'a',
+			(byte)'C',
+			(byte)'l',
+			(byte)'a',
+			(byte)'s',
+			(byte)'s',
+			(byte)'\0',
+
+			// 1st Data Type (Boolean)
+			0x00,
+			0x00,
+			0x00,
+			0x00,
+
+			(byte)'P',
+			(byte)'L',
+			(byte)'_',
+			(byte)'A',
+			(byte)'t',
+			(byte)'s',
+			(byte)'S',
+			(byte)'_',
+			(byte)'W',
+			(byte)'h',
+			(byte)'i',
+			(byte)'t',
+			(byte)'e',
+			(byte)'\0',
+
+			// 2nd Data Type (Boolean)
+			0x00,
+			0x00,
+			0x00,
+			0x00,
+
+			(byte)'P',
+			(byte)'L',
+			(byte)'_',
+			(byte)'A',
+			(byte)'t',
+			(byte)'s',
+			(byte)'S',
+			(byte)'_',
+			(byte)'R',
+			(byte)'e',
+			(byte)'d',
+			(byte)'\0',
+		}));
+	}
+}

--- a/BIDSSMemLib.Variable.Tests/BIDSSMemLib.Variable.Tests.csproj
+++ b/BIDSSMemLib.Variable.Tests/BIDSSMemLib.Variable.Tests.csproj
@@ -19,6 +19,10 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="TR.SMemIF.Mock" Version="1.1.0.1" />
+		<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\BIDSSMemLib.Variable\BIDSSMemLib.Variable.csproj" />

--- a/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
+++ b/BIDSSMemLib.Variable/BIDSSMemLib.Variable.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
-		<Version>1.3.2</Version>
+		<Version>1.3.3</Version>
 		<Nullable>enable</Nullable>
 		<Assemblyname>TR.BIDSSMemLib.Variable</Assemblyname>
 		<RootNamespace>TR.BIDSSMemLib</RootNamespace>

--- a/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
@@ -47,7 +47,11 @@ public partial class VariableSMem
 		if (!SMemIF.ReadArray(StructureAreaOffset, structureBytes, 0, structureBytes.Length))
 			throw new AccessViolationException("Read from SMem failed");
 
-		VariableStructure structure = VariableCmdParser.ParseDataTypeRegisterCommand(structureBytes);
+		VariableStructure structure = VariableCmdParser.ParseDataTypeRegisterCommand(structureBytes)
+			with
+		{
+			Name = SMemIF.SMemName
+		};
 
 		return new VariableSMem(SMemIF, structure);
 	}

--- a/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.StaticFuncs.cs
@@ -30,7 +30,7 @@ public partial class VariableSMem
 	public static VariableSMem CreateWithoutType(ISMemIF SMemIF)
 	{
 		if (SMemIF.IsNewlyCreated)
-			throw new NotInitializedException(nameof(SMemIF.SMemName));
+			throw new NotInitializedException(SMemIF.SMemName);
 
 		if (!SMemIF.Read(0, out long contentAreaOffset))
 			throw new AccessViolationException("Read from SMem failed");

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -151,7 +151,13 @@ public partial class VariableSMem : IDisposable
 	/// <returns>ContentAreaOffset</returns>
 	long InitSMem()
 	{
-		byte[] structureBytes = Structure.GetStructureBytes().ToArray();
+		// DataTypeIdとStructure Nameは不要なので、意味のない値にする
+		// 本当は削除してしまいたいけど、Parseプロセスの都合で残す。
+		byte[] structureBytes = (Structure with
+		{
+			DataTypeId = -1,
+			Name = string.Empty,
+		}).GetStructureBytes().ToArray();
 
 		long contentAreaOffset
 			= StructureAreaOffset

--- a/BIDSSMemLib.Variable/VariableSMem.cs
+++ b/BIDSSMemLib.Variable/VariableSMem.cs
@@ -130,8 +130,9 @@ public partial class VariableSMem : IDisposable
 		_Members = members.ToList();
 		if (structure is null)
 		{
-			// Structure Nameは、共有メモリにおいてはSMemNameで代替できるため、記録しない
-			Structure = new(-1, string.Empty, _Members);
+			// Structure Nameは、共有メモリにおいてはSMemNameで代替できるものの、Parseプロセスの都合上、これも記録するようにする。
+			// なお、将来的には記録しないようにしたい。
+			Structure = new(-1, Name, _Members);
 		}
 		else
 		{

--- a/VariableSMemMonitor.Core.Tests/VariableSMemAutoReader.Tests.cs
+++ b/VariableSMemMonitor.Core.Tests/VariableSMemAutoReader.Tests.cs
@@ -1,0 +1,161 @@
+using TR;
+using TR.BIDSSMemLib;
+using TR.VariableSMemMonitor.Core;
+
+namespace VariableSMemMonitor.Core.Tests;
+
+public class VariableSMemAutoReaderTests
+{
+	// Without Array
+	class BasicSampleClass
+	{
+		public int IntValue { get; set; }
+
+		public ushort UInt16Value { get; set; }
+	}
+
+	class ArraySampleClass : BasicSampleClass
+	{
+		public string SampleString = string.Empty;
+
+		public double[] SampleDoubleArr { get; set; } = Array.Empty<double>();
+	}
+
+	[Test]
+	public void BasicSampleClassInitTest()
+	{
+		SMemIFMock memory = new("test", 0x1000);
+
+		VariableSMem<BasicSampleClass> VSMem = new(memory);
+		BasicSampleClass data = new();
+
+		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
+
+		VariableSMemWatcher.ChangedValues changedValues = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues.SMemName, Is.EqualTo(memory.SMemName));
+
+			// 初期化時点から変化がないため、`ChangedValue`も存在しない。
+			// なお、初期値は`ChangedValue`に含まれない。
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.Zero);
+		});
+	}
+
+	[Test]
+	public void ArraySampleClassInitTest()
+	{
+		SMemIFMock memory = new("test", 0x1000);
+
+		VariableSMem<ArraySampleClass> VSMem = new(memory);
+
+		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
+
+		VariableSMemWatcher.ChangedValues changedValues = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues.SMemName, Is.EqualTo(memory.SMemName));
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.Zero);
+		});
+	}
+
+	[Test]
+	public void BasicSampleClassSetValueTest()
+	{
+		SMemIFMock memory = new("test", 0x1000);
+
+		VariableSMem<BasicSampleClass> VSMem = new(memory);
+
+		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
+
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
+
+		BasicSampleClass data = new()
+		{
+			IntValue = 2,
+			UInt16Value = 3
+		};
+		VSMem.Write(data);
+
+		VariableSMemWatcher.ChangedValues changedValues = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.EqualTo(2));
+
+			Assert.That(changedValues.ChangedValuesDic[nameof(BasicSampleClass.IntValue)], Is.EqualTo(data.IntValue));
+			Assert.That(changedValues.ChangedValuesDic[nameof(BasicSampleClass.UInt16Value)], Is.EqualTo(data.UInt16Value));
+		});
+
+		// 最後にチェックしてから何もWriteしていないため、データの更新は無い。
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
+
+		// 一つのメンバだけを更新すると、更新通知も一つだけになる
+		data.IntValue = -2;
+		VSMem.Write(data);
+
+		VariableSMemWatcher.ChangedValues changedValues1 = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues1.ChangedValuesDic, Has.Count.EqualTo(1));
+
+			Assert.That(changedValues1.ChangedValuesDic[nameof(BasicSampleClass.IntValue)], Is.EqualTo(data.IntValue));
+		});
+	}
+
+	[Test]
+	public void ArraySampleClassSetValueTest()
+	{
+		SMemIFMock memory = new("test", 0x1000);
+
+		VariableSMem<ArraySampleClass> VSMem = new(memory);
+
+		VariableSMemWatcher monitor = new(new SMemIFMock(memory));
+
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
+
+		ArraySampleClass data = new()
+		{
+			IntValue = 2,
+			UInt16Value = 3,
+			SampleString = "testTEST__Test String",
+			SampleDoubleArr = new double[] { 1.2, 3.4 },
+		};
+		VSMem.Write(data);
+
+		VariableSMemWatcher.ChangedValues changedValues = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues.ChangedValuesDic, Has.Count.EqualTo(4));
+
+			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.IntValue)], Is.EqualTo(data.IntValue));
+			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.UInt16Value)], Is.EqualTo(data.UInt16Value));
+			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleString)], Is.EqualTo(data.SampleString));
+			Assert.That(changedValues.ChangedValuesDic[nameof(ArraySampleClass.SampleDoubleArr)], Is.EquivalentTo(data.SampleDoubleArr));
+		});
+
+		// 最後にチェックしてから何もWriteしていないため、データの更新は無い。
+		Assert.That(monitor.CheckForValueChange().ChangedValuesDic, Has.Count.Zero);
+
+		// 一部のメンバだけを更新
+		data.IntValue = -2;
+		data.SampleString = string.Empty;
+		data.SampleDoubleArr = new double[]
+		{
+			9.8,
+			7.6,
+			5.4,
+			3.2,
+		};
+		VSMem.Write(data);
+
+		VariableSMemWatcher.ChangedValues changedValues1 = monitor.CheckForValueChange();
+		Assert.Multiple(() =>
+		{
+			Assert.That(changedValues1.ChangedValuesDic, Has.Count.EqualTo(3));
+
+			Assert.That(changedValues1.ChangedValuesDic[nameof(ArraySampleClass.IntValue)], Is.EqualTo(data.IntValue));
+			Assert.That(changedValues1.ChangedValuesDic[nameof(ArraySampleClass.SampleString)], Is.EqualTo(data.SampleString));
+			Assert.That(changedValues1.ChangedValuesDic[nameof(ArraySampleClass.SampleDoubleArr)], Is.EquivalentTo(data.SampleDoubleArr));
+		});
+	}
+}

--- a/VariableSMemMonitor.Core.Tests/VariableSMemMonitor.Core.Tests.csproj
+++ b/VariableSMemMonitor.Core.Tests/VariableSMemMonitor.Core.Tests.csproj
@@ -19,6 +19,10 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="TR.SMemIF.Mock" Version="1.1.0.1" />
+		<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\VariableSMemMonitor.Core\VariableSMemMonitor.Core.csproj" />

--- a/VariableSMemMonitor.Core/VariableSMemAutoReader.cs
+++ b/VariableSMemMonitor.Core/VariableSMemAutoReader.cs
@@ -70,25 +70,30 @@ public class VariableSMemAutoReader : IDisposable
 	{
 		while (!disposingValue)
 		{
-			IReadOnlyList<string> newNames = SMemNameWatcher.CheckNewName();
-
-			foreach (var newName in newNames)
-			{
-				VariableSMemWatcher vsmemWatcher = GenerateVariableSMemWatcher(newName);
-				VariableSMemWatcherDic.Add(newName, vsmemWatcher);
-
-				NameAdded?.Invoke(this, new(newName, vsmemWatcher.Structure));
-			}
-
-			foreach (var watcher in VariableSMemWatcherDic.Values)
-			{
-				var v = watcher.CheckForValueChange();
-
-				if (v.ChangedValuesDic.Count > 0)
-					ValueChanged?.Invoke(this, v);
-			}
+			ReadOnce();
 
 			await Task.Delay(Interval_ms);
+		}
+	}
+
+	public void ReadOnce()
+	{
+		IReadOnlyList<string> newNames = SMemNameWatcher.CheckNewName();
+
+		foreach (var newName in newNames)
+		{
+			VariableSMemWatcher vsmemWatcher = GenerateVariableSMemWatcher(newName);
+			VariableSMemWatcherDic.Add(newName, vsmemWatcher);
+
+			NameAdded?.Invoke(this, new(newName, vsmemWatcher.Structure));
+		}
+
+		foreach (var watcher in VariableSMemWatcherDic.Values)
+		{
+			var v = watcher.CheckForValueChange();
+
+			if (v.ChangedValuesDic.Count > 0)
+				ValueChanged?.Invoke(this, v);
 		}
 	}
 

--- a/VariableSMemMonitor.Core/VariableSMemAutoReader.cs
+++ b/VariableSMemMonitor.Core/VariableSMemAutoReader.cs
@@ -32,13 +32,31 @@ public class VariableSMemAutoReader : IDisposable
 
 	Task? AutoReadTask = null;
 
-	public VariableSMemAutoReader(int Interval_ms)
+	Func<string, VariableSMemWatcher> VariableSMemWatcherGenerator { get; } = GenerateVariableSMemWatcher;
+	static VariableSMemWatcher GenerateVariableSMemWatcher(string name)
+		=> new(name);
+
+
+	public VariableSMemAutoReader(int Interval_ms) : this(Interval_ms, new())
+	{
+	}
+
+	public VariableSMemAutoReader(int Interval_ms, NameSMemWatcher SMemNameWatcher)
 	{
 		VariableSMemWatcherDic = new();
 
-		SMemNameWatcher = new();
+		this.SMemNameWatcher = SMemNameWatcher;
 
 		this.Interval_ms = Interval_ms;
+	}
+
+	public VariableSMemAutoReader(
+		int Interval_ms,
+		NameSMemWatcher SMemNameWatcher,
+		Func<string, VariableSMemWatcher> VariableSMemWatcherGenerator
+	) : this(Interval_ms, SMemNameWatcher)
+	{
+		this.VariableSMemWatcherGenerator = VariableSMemWatcherGenerator;
 	}
 
 	public Task Run()
@@ -56,7 +74,7 @@ public class VariableSMemAutoReader : IDisposable
 
 			foreach (var newName in newNames)
 			{
-				VariableSMemWatcher vsmemWatcher = new(newName);
+				VariableSMemWatcher vsmemWatcher = GenerateVariableSMemWatcher(newName);
 				VariableSMemWatcherDic.Add(newName, vsmemWatcher);
 
 				NameAdded?.Invoke(this, new(newName, vsmemWatcher.Structure));

--- a/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
+++ b/VariableSMemMonitor.Core/VariableSMemMonitor.Core.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<LangVersion>10</LangVersion>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<Nullable>enable</Nullable>
 		<AssemblyName>TR.VariableSMemMonitor.Core</AssemblyName>
 		<RootNamespace>TR.VariableSMemMonitor.Core</RootNamespace>


### PR DESCRIPTION
- 共有メモリ内に可変構造の構造名を保存しない仕様のせいで、共有メモリから構造を読み取った結果の`VariableStructure`に構造名が保存されないバグを修正
- 共有メモリが初期化されていない際の例外メッセージで、共有メモリ名ではなく変数名を出力していたバグを修正

ほか、一部テスト追加